### PR TITLE
Modify resetSlider to reset color on clear

### DIFF
--- a/src/app/containers/ActionContainer.tsx
+++ b/src/app/containers/ActionContainer.tsx
@@ -12,8 +12,10 @@ import { Obj } from '../FrontendTypes';
 
 const resetSlider = () => {
   const slider = document.querySelector('.rc-slider-handle');
+  const sliderTrack = document.querySelector('.rc-slider-track');
   if (slider) {
     slider.setAttribute('style', 'left: 0');
+    sliderTrack.setAttribute('style', 'width: 0');
   }
 };
 


### PR DESCRIPTION
When clearing snapshots, the slider was not resetting its background color properly. Added functionality to the resetSlider function to handle this. 