### PR TITLE
Remove persist deprecated feature and debug timeJump

### DIFF
--- a/src/app/__tests__/ButtonContainer.test.tsx
+++ b/src/app/__tests__/ButtonContainer.test.tsx
@@ -26,7 +26,6 @@ describe('Unit testing for ButtonContainer', () => {
         mode: {
           paused: false,
           locked: false,
-          persist: false,
         },
       },
     },
@@ -47,7 +46,6 @@ describe('Unit testing for ButtonContainer', () => {
     mockedUsedStoreContext.mockClear();
     currentTab.mode = {
       paused: false,
-      persist: false,
     };
   });
 

--- a/src/app/__tests__enzyme/ignore/ButtonsContainer.test.tsx
+++ b/src/app/__tests__enzyme/ignore/ButtonsContainer.test.tsx
@@ -18,7 +18,6 @@ const state = {
       mode: {
         paused: false,
         locked: false,
-        persist: false,
       },
     },
   },
@@ -42,7 +41,6 @@ describe('testing the bottom buttons', () => {
     useStoreContext.mockClear();
     currentTab.mode = {
       paused: false,
-      persist: false,
     };
   });
 
@@ -66,24 +64,4 @@ describe('testing the bottom buttons', () => {
     });
   });
 
-  describe.skip('persist button testing', () => {
-    beforeEach(() => {
-      wrapper.find('.persist-button').simulate('click');
-    });
-
-    test('persist button dispatches upon click', () => {
-      expect(dispatch.mock.calls.length).toBe(1);
-    });
-
-    test('persist button dispatches toggleMode action', () => {
-      expect(dispatch.mock.calls[0][0]).toEqual(toggleMode('persist'));
-    });
-
-    test('persist button displays state', () => {
-      expect(wrapper.find('.persist-button').text()).toBe('<FontAwesomeIcon />Persist');
-      state.tabs[state.currentTab].mode.persist = true;
-      wrapper = shallow(<ButtonsContainer />);
-      expect(wrapper.find('.persist-button').text()).toBe('<FontAwesomeIcon />Unpersist');
-    });
-  });
 });

--- a/src/app/__tests__enzyme/ignore/mainReducer.test.tsx
+++ b/src/app/__tests__enzyme/ignore/mainReducer.test.tsx
@@ -32,7 +32,6 @@ describe('mainReducer testing', () => {
           mode: {
             paused: false,
             locked: false,
-            persist: false,
           },
           intervalId: 87,
           playing: true,
@@ -116,7 +115,6 @@ describe('mainReducer testing', () => {
           mode: {
             paused: false,
             locked: false,
-            persist: false,
           },
           intervalId: 75,
           playing: false,
@@ -279,25 +277,16 @@ describe('mainReducer testing', () => {
       const { mode } = mainReducer(state, toggleMode('paused')).tabs[currentTab];
       expect(mode.paused).toBe(true);
       expect(mode.locked).toBe(false);
-      expect(mode.persist).toBe(false);
     });
     it('clicking lock button should only change lock mode', () => {
       const { mode } = mainReducer(state, toggleMode('locked')).tabs[currentTab];
       expect(mode.paused).toBe(false);
       expect(mode.locked).toBe(true);
-      expect(mode.persist).toBe(false);
-    });
-    it('clicking persist button should only change persist mode', () => {
-      const { mode } = mainReducer(state, toggleMode('persist')).tabs[currentTab];
-      expect(mode.paused).toBe(false);
-      expect(mode.locked).toBe(false);
-      expect(mode.persist).toBe(true);
     });
     it('undefined payload does nothing', () => {
       const { mode } = mainReducer(state, toggleMode('undefined')).tabs[currentTab];
       expect(mode.paused).toBe(false);
       expect(mode.locked).toBe(false);
-      expect(mode.persist).toBe(false);
     });
   });
 
@@ -326,7 +315,6 @@ describe('mainReducer testing', () => {
         mode: {
           paused: false,
           locked: false,
-          persist: false,
         },
         intervalId: 912,
         playing: true,

--- a/src/app/reducers/mainReducer.js
+++ b/src/app/reducers/mainReducer.js
@@ -217,9 +217,6 @@ export default (state, action) =>
           case 'paused':
             actionText = 'setPause';
             break;
-          case 'persist':
-            actionText = 'setPersist';
-            break;
           default:
             break;
         }

--- a/src/backend/controllers/timeJump.ts
+++ b/src/backend/controllers/timeJump.ts
@@ -70,11 +70,14 @@ async function updateReactFiberTree(
   if (index !== null) {
     // Obtain the BOUND update method at the given index
     const classComponent = componentActionsRecord.getComponentByIndex(index);
-    // Update component state
-    await classComponent.setState(
-      // prevState contains the states of the snapshots we are jumping FROM, not jumping TO
-      (prevState) => state,
-    );
+    // This conditional avoids the error that occurs when classComponent is undefined
+    if (classComponent !== undefined) {
+      // Update component state
+      await classComponent.setState(
+        // prevState contains the states of the snapshots we are jumping FROM, not jumping TO
+        (prevState) => state,
+      );
+    }
     // Iterate through new children after state has been set
     targetSnapshot.children.forEach((child) => updateReactFiberTree(child, circularComponentTable));
     return;

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -42,9 +42,8 @@ function createTabObj(title) {
       reactDevToolsInstalled: false,
       targetPageisaReactApp: false,
     },
-    // Note: Persist is a now defunct feature. Paused = Locked
+    // Note: Paused = Locked
     mode: {
-      persist: false,
       paused: false,
     },
     // stores web metrics calculated by the content script file
@@ -203,10 +202,6 @@ chrome.runtime.onConnect.addListener((port) => {
       // Pause = lock on tab
       case 'setPause':
         tabsObj[tabId].mode.paused = payload;
-        return true;
-      // persist is now depreacted
-      case 'setPersist':
-        tabsObj[tabId].mode.persist = payload;
         return true;
       case 'launchContentScript':
         chrome.scripting.executeScript({


### PR DESCRIPTION
The persist feature was deprecated, so I removed it from the codebase. 

Separately, I Identified a bug in timeJump when sometimes classComponent is undefined, so Reactime throws an error when the setState method on classComponent attempts to be invoked. Wrapping the invocation of setState in a conditional for this edge case resolves this bug.