### PR TITLE
Debug setState error in timeJump

### DIFF
--- a/src/backend/controllers/timeJump.ts
+++ b/src/backend/controllers/timeJump.ts
@@ -70,11 +70,14 @@ async function updateReactFiberTree(
   if (index !== null) {
     // Obtain the BOUND update method at the given index
     const classComponent = componentActionsRecord.getComponentByIndex(index);
-    // Update component state
-    await classComponent.setState(
-      // prevState contains the states of the snapshots we are jumping FROM, not jumping TO
-      (prevState) => state,
-    );
+    // This conditional avoids the error that occurs when classComponent is undefined
+    if (classComponent !== undefined) {
+      // Update component state
+      await classComponent.setState(
+        // prevState contains the states of the snapshots we are jumping FROM, not jumping TO
+        (prevState) => state,
+      );
+    }
     // Iterate through new children after state has been set
     targetSnapshot.children.forEach((child) => updateReactFiberTree(child, circularComponentTable));
     return;


### PR DESCRIPTION
Identified a bug in timeJump when sometimes classComponent is undefined, so Reactime throws an error when the setState method on classComponent attempts to be invoked. Wrapping the invocation of setState in a conditional for this edge case resolves this bug. 