### PR TITLE
Change default setting of tab to "Locked"

### DIFF
--- a/src/app/__tests__/ButtonContainer.test.tsx
+++ b/src/app/__tests__/ButtonContainer.test.tsx
@@ -24,7 +24,7 @@ describe('Unit testing for ButtonContainer', () => {
         sliderIndex: 0,
         viewIndex: -1,
         mode: {
-          paused: false,
+          paused: true,
           locked: false,
           persist: false,
         },
@@ -46,7 +46,7 @@ describe('Unit testing for ButtonContainer', () => {
     dispatch.mockClear();
     mockedUsedStoreContext.mockClear();
     currentTab.mode = {
-      paused: false,
+      paused: true,
       persist: false,
     };
   });
@@ -55,7 +55,7 @@ describe('Unit testing for ButtonContainer', () => {
     test('should have 4 buttons ', () => {
       render(<ButtonsContainer />);
       expect(screen.getAllByRole('button')).toHaveLength(4);
-      expect(screen.getAllByRole('button')[0]).toHaveTextContent('Unlocked');
+      expect(screen.getAllByRole('button')[0]).toHaveTextContent('Locked');
       expect(screen.getAllByRole('button')[1]).toHaveTextContent('Download');
       expect(screen.getAllByRole('button')[2]).toHaveTextContent('Upload');
       expect(screen.getAllByRole('button')[3]).toHaveTextContent('Tutorial');
@@ -64,9 +64,9 @@ describe('Unit testing for ButtonContainer', () => {
 
   describe('When view is unlock', () => {
     test('Button should show as unlocked', () => {
-      state.tabs['87'].mode.paused = true;
+      state.tabs['87'].mode.paused = false;
       render(<ButtonsContainer />);
-      expect(screen.getAllByRole('button')[0]).toHaveTextContent('Locked');
+      expect(screen.getAllByRole('button')[0]).toHaveTextContent('Unlocked');
     });
   });
 

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -45,7 +45,7 @@ function createTabObj(title) {
     // Note: Persist is a now defunct feature. Paused = Locked
     mode: {
       persist: false,
-      paused: false,
+      paused: true,
     },
     // stores web metrics calculated by the content script file
     webMetrics: {},


### PR DESCRIPTION
Changed the default state so tab selection is "locked" on initial load. This is for improved DX - the "unlocked" setting unintentionally triggers the error page often, so "locked" makes more sense as a default setting. Also updated the ButtonContainer tests to reflect this change. 