### PR TITLE
Make action tests more robust

### DIFF
--- a/src/app/__tests__/action.test.tsx
+++ b/src/app/__tests__/action.test.tsx
@@ -87,14 +87,14 @@ describe('unit testing for Action.tsx', () => {
     test('Clicking the snapshot should trigger onClick', () => {
       render(<Action {...props} />);
       fireEvent.click(screen.getByRole('presentation'));
-      expect(props.dispatch).toHaveBeenCalledWith(changeView(2));;
+      expect(props.dispatch).toHaveBeenCalledWith(changeView(props.index));;
     });
 
     test('Clicking Jump button should trigger changeSlider and changeView', () => {
       render(<Action {...props} />);
       fireEvent.click(screen.getAllByRole('button')[1]);
-      expect(props.dispatch).toHaveBeenCalledWith(changeSlider(2));
-      expect(props.dispatch).toHaveBeenCalledWith(changeView(2));
+      expect(props.dispatch).toHaveBeenCalledWith(changeSlider(props.index));
+      expect(props.dispatch).toHaveBeenCalledWith(changeView(props.index));
     });
   });
 });


### PR DESCRIPTION
Make the click tests in action.test more robust by passing in props as an argument